### PR TITLE
USB Serial fix for recieve

### DIFF
--- a/BSP/Src/usbd_cdc_interface.c
+++ b/BSP/Src/usbd_cdc_interface.c
@@ -11,6 +11,13 @@ USBD_CDC_LineCodingTypeDef LineCoding =
 
 extern USBD_HandleTypeDef  USBD_Device;
 
+#define APP_RX_DATA_SIZE 1024
+#define APP_TX_DATA_SIZE 1024
+
+uint8_t user_RX_buf[APP_RX_DATA_SIZE];
+
+uint8_t user_TX_buf[APP_TX_DATA_SIZE];
+
 static int8_t CDC_Itf_Init(void);
 static int8_t CDC_Itf_DeInit(void);
 static int8_t CDC_Itf_Control(uint8_t cmd, uint8_t* pbuf, uint16_t length);
@@ -26,6 +33,9 @@ USBD_CDC_ItfTypeDef USBD_CDC_fops =
 
 static int8_t CDC_Itf_Init(void)
 { 
+  USBD_CDC_SetRxBuffer(&USBD_Device, user_RX_buf);
+  USBD_CDC_SetTxBuffer(&USBD_Device, user_TX_buf, 0);
+
   return (USBD_OK);
 }
 
@@ -96,5 +106,7 @@ static int8_t CDC_Itf_Control (uint8_t cmd, uint8_t* pbuf, uint16_t length)
 
 static int8_t CDC_Itf_Receive(uint8_t* Buf, uint32_t *Len)
 {
+  USBD_CDC_SetRxBuffer(&USBD_Device, user_RX_buf);
+  USBD_CDC_ReceivePacket(&USBD_Device);
   return (USBD_OK);
 }

--- a/BSP/flash.ld
+++ b/BSP/flash.ld
@@ -34,8 +34,8 @@ ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
 /* Generate a link error if heap and stack don't fit into RAM */
-_Min_Heap_Size = 0x200;      /* required amount of heap  */
-_Min_Stack_Size = 0x400; /* required amount of stack */
+_Min_Heap_Size = 0x2200;      /* required amount of heap  */
+_Min_Stack_Size = 0x2400; /* required amount of stack */
 
 /* Specify the memory areas */
 MEMORY

--- a/BSP/flash.ld
+++ b/BSP/flash.ld
@@ -34,8 +34,8 @@ ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
 /* Generate a link error if heap and stack don't fit into RAM */
-_Min_Heap_Size = 0x2200;      /* required amount of heap  */
-_Min_Stack_Size = 0x2400; /* required amount of stack */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
 
 /* Specify the memory areas */
 MEMORY

--- a/armv7hf
+++ b/armv7hf
@@ -18,7 +18,7 @@ CC=arm-none-eabi-gcc
 CXX=arm-none-eabi-g++
 OBJCOPY=arm-none-eabi-objcopy
 SIZE_UTIL=arm-none-eabi-size
-LDFLAGS="--specs=nosys.specs"
+LDFLAGS="--specs=nosys.specs --specs=nano.specs"
 CFLAGS="$C_MACHINE_OPTIONS"
-CXXFLAGS="$C_MACHINE_OPTIONS"
+CXXFLAGS="$C_MACHINE_OPTIONS -fno-exceptions -fno-rtti"
 ASMFLAGS="$C_MACHINE_OPTIONS"

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ all : build/conaninfo.txt
 	conan build . -bf build
 
 C_FIRMWARE_TESTS = blink gpio flash usb_serial spi
-CPP_FIRMWARE_TESTS = blink gpio spi
+CPP_FIRMWARE_TESTS = blink gpio spi usb_serial
 
 $(C_FIRMWARE_TESTS:%=upload-%-c): configure
 	cd build; make $(@F)

--- a/tests/c/usb_serial.c
+++ b/tests/c/usb_serial.c
@@ -20,7 +20,6 @@ int main(void) {
     USBD_CDC_RegisterInterface(&USBD_Device, &USBD_CDC_fops);
     USBD_Start(&USBD_Device);
 
-    fflush(stdin);
     fflush(stdout);
 
     for (;;) {
@@ -38,8 +37,8 @@ int main(void) {
         digitalout_toggle(leds[2]);
         HAL_Delay(5);
 
-        fflush(stdin);
         printf("t\r\n");
+        printf("a\r\n");
         fflush(stdout);
     }
 }

--- a/tests/c/usb_serial.c
+++ b/tests/c/usb_serial.c
@@ -1,42 +1,54 @@
-
-
 #include "mtrain.h"
+
+#include "bsp.h"
+
+//for debugging
 #include  <unistd.h>
+USBD_HandleTypeDef USBD_Device;
 
-// USBD_HandleTypeDef USBD_Device;
+int main(void) {
 
-int main(void)
-{
-    // USBD_Init(&USBD_Device, &VCP_Desc, 0);
-    // USBD_RegisterClass(&USBD_Device, USBD_CDC_CLASS);
-    // USBD_CDC_RegisterInterface(&USBD_Device, &USBD_CDC_fops);
-    // USBD_Start(&USBD_Device);
+    digitalout_init(LED1);
+    digitalout_init(LED2);
+    digitalout_init(LED3);
+    digitalout_init(LED4);
+    
+    pin_name leds[] = {LED1, LED2, LED3, LED4};
+    
+    USBD_Init(&USBD_Device, &VCP_Desc, 0);
+    USBD_RegisterClass(&USBD_Device, USBD_CDC_CLASS);
+    USBD_CDC_RegisterInterface(&USBD_Device, &USBD_CDC_fops);
+    USBD_Start(&USBD_Device);
 
-    // GPIO_InitTypeDef GPIO_InitStruct;
+    fflush(stdin);
+    fflush(stdout);
 
-    // GPIO_InitStruct.Pin = LED1_PIN;
-    // GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    // GPIO_InitStruct.Pull = GPIO_PULLUP;
-    // GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-    // HAL_GPIO_Init(LED_PORT, &GPIO_InitStruct);
-    // HAL_GPIO_WritePin(LED_PORT, LED1_PIN, GPIO_PIN_SET);
+    for (;;) {
+        digitalout_toggle(leds[0]);
+        HAL_Delay(5);
+        digitalout_toggle(leds[1]);
+        HAL_Delay(5);
+        digitalout_toggle(leds[2]);
+        HAL_Delay(5);
+        
+        digitalout_toggle(leds[0]);
+        HAL_Delay(5);
+        digitalout_toggle(leds[1]);
+        HAL_Delay(5);
+        digitalout_toggle(leds[2]);
+        HAL_Delay(5);
 
-    // fflush(stdout);
-
-    // int count = 0;
-    // while(1) {
-    //     HAL_Delay(100);
-    //     printf("\r%d", count);
-    //     fflush(stdout);
-    //     count++;
-    // }
+        fflush(stdin);
+        printf("t\r\n");
+        fflush(stdout);
+    }
 }
 
-// int _write(int file, char *data, int len)
-// {
-//     if (file == STDOUT_FILENO) {
-//         USBD_CDC_SetTxBuffer(&USBD_Device, (uint8_t*)data, len);
-//         USBD_CDC_TransmitPacket(&USBD_Device);
-//     }
-//     return 0;
-// }
+int _write(int file, char *data, int len)
+{
+    if (file == STDOUT_FILENO && USBD_Device.dev_state == USBD_STATE_CONFIGURED ) {
+        USBD_CDC_SetTxBuffer(&USBD_Device, (uint8_t*)data, len);
+        USBD_CDC_TransmitPacket(&USBD_Device);
+    }
+    return 0;
+}

--- a/tests/c/usb_serial.c
+++ b/tests/c/usb_serial.c
@@ -45,7 +45,7 @@ int main(void) {
 
 int _write(int file, char *data, int len)
 {
-    if (file == STDOUT_FILENO && USBD_Device.dev_state == USBD_STATE_CONFIGURED ) {
+    if (file == STDOUT_FILENO) {
         USBD_CDC_SetTxBuffer(&USBD_Device, (uint8_t*)data, len);
         USBD_CDC_TransmitPacket(&USBD_Device);
     }

--- a/tests/cpp/usb_serial.cpp
+++ b/tests/cpp/usb_serial.cpp
@@ -13,7 +13,6 @@ int main() {
     USBD_CDC_RegisterInterface(&USBD_Device, &USBD_CDC_fops);
     USBD_Start(&USBD_Device);
 
-    // Crashes
     DigitalOut l1 = DigitalOut(LED2);
 
     fflush(stdout);

--- a/tests/cpp/usb_serial.cpp
+++ b/tests/cpp/usb_serial.cpp
@@ -1,0 +1,53 @@
+#include "mtrain.hpp"
+
+#include "bsp.h"
+#include  <unistd.h>
+
+#include "PinDefs.hpp"
+
+USBD_HandleTypeDef USBD_Device;
+
+// Doesn't crash
+// DigitalOut l1 = DigitalOut(LED2);
+
+int main() {
+    USBD_Init(&USBD_Device, &VCP_Desc, 0);
+    USBD_RegisterClass(&USBD_Device, USBD_CDC_CLASS);
+    USBD_CDC_RegisterInterface(&USBD_Device, &USBD_CDC_fops);
+    USBD_Start(&USBD_Device);
+
+    // Crashes
+    //DigitalOut l1 = DigitalOut(LED2);
+
+    // Doesn't crash
+    //GPIO_InitTypeDef pin_structure = {};
+    //pin_structure.Pin = LED2.pin;
+    //pin_structure.Mode = PinMode::PushPull;
+    //pin_structure.Pull = PullType::PullNone;
+    //pin_structure.Speed = PinSpeed::Low;
+    
+    //HAL_GPIO_Init(LED2.port, &pin_structure);
+
+    fflush(stdout);
+
+    for (;;) {
+        HAL_Delay(5);
+
+        printf("t\r\n");
+        fflush(stdout);
+    }
+
+  while (true) { }
+}
+
+extern "C" {
+
+int _write(int file, char *data, int len)
+{
+    if (file == STDOUT_FILENO) {
+        USBD_CDC_SetTxBuffer(&USBD_Device, (uint8_t*)data, len);
+        USBD_CDC_TransmitPacket(&USBD_Device);
+    }
+    return 0;
+}
+}

--- a/tests/cpp/usb_serial.cpp
+++ b/tests/cpp/usb_serial.cpp
@@ -7,9 +7,6 @@
 
 USBD_HandleTypeDef USBD_Device;
 
-// Doesn't crash
-// DigitalOut l1 = DigitalOut(LED2);
-
 int main() {
     USBD_Init(&USBD_Device, &VCP_Desc, 0);
     USBD_RegisterClass(&USBD_Device, USBD_CDC_CLASS);
@@ -17,27 +14,24 @@ int main() {
     USBD_Start(&USBD_Device);
 
     // Crashes
-    //DigitalOut l1 = DigitalOut(LED2);
-
-    // Doesn't crash
-    //GPIO_InitTypeDef pin_structure = {};
-    //pin_structure.Pin = LED2.pin;
-    //pin_structure.Mode = PinMode::PushPull;
-    //pin_structure.Pull = PullType::PullNone;
-    //pin_structure.Speed = PinSpeed::Low;
-    
-    //HAL_GPIO_Init(LED2.port, &pin_structure);
+    DigitalOut l1 = DigitalOut(LED2);
 
     fflush(stdout);
 
-    for (;;) {
-        HAL_Delay(5);
+    uint8_t i = 0;
 
-        printf("t\r\n");
+    for (;;) {
+        l1 = 0;
+        
+        HAL_Delay(50);
+        
+        l1 = 1;
+
+        HAL_Delay(50);
+
+        printf("%u\r\n", i++);
         fflush(stdout);
     }
-
-  while (true) { }
 }
 
 extern "C" {


### PR DESCRIPTION
I'm 90% sure this solves the problem below. I believe that we never set the RX buffer location, so each end point was just throwing data into memory somewhere. Additionally, I think you have to call `USBD_CDC_ReceivePacket` every time a packet is received to receive the next one. I believe there is another buffer somewhere that holds these packets until we call that, which may also be filling up and dying. Both theories can explain the crash happening a few seconds after startup.

The `xfer_buff` of each endpoint is only set in `HAL_PCD_EP_Recieve`, which is only called from `USBD_LL_PrepareReceive`, which (for CDC) is called in `USBD_CDC_Init`. We need to setup everything before this is called. The challenge is that this is called in some `OTG_HS_IRQHandler` interrupt. There are callbacks which are exposed to the user side which we can use to set everything up (All the `CDC_Itf` stuff). 

```
#0  Handler_Loop () at /home/joe/mtrain-firmware/BSP/Src/default_handlers.c:3
#1  <signal handler called>
#2  0x08008fac in USB_ReadPacket (USBx=0x40040000, 
    dest=0xe45b1647 <error: Cannot access memory at address 0xe45b1647>, len=1)
    at /home/joe/mtrain-firmware/external/STM32F7xx_HAL_Drivers/Src/stm32f7xx_ll_usb.c:846
#3  0x08004a14 in HAL_PCD_IRQHandler (hpcd=0x20000450 <hpcd>)
    at /home/joe/mtrain-firmware/external/STM32F7xx_HAL_Drivers/Src/stm32f7xx_hal_pcd.c:644
#4  0x08000f76 in OTG_HS_IRQHandler ()
    at /home/joe/mtrain-firmware/BSP/Src/interrupt_handlers.c:17
#5  <signal handler called>
```
***
I think the printf `_write` can be improved as well. I think that if we print out too much in a row, the USB doesn't have enough time to send it so we just end up over writing the previous packet. Additionally, who actually destroys the buffers? It might be leaking memory if nobody destroys them