### PR TITLE
Fixes for RTOS

### DIFF
--- a/BSP/Src/bsp.c
+++ b/BSP/Src/bsp.c
@@ -34,7 +34,7 @@ int _write(int file, char *data, int len)
     if (file == STDOUT_FILENO) {
         USBD_CDC_SetTxBuffer(&USBD_Device, (uint8_t*)data, len);
         USBD_CDC_TransmitPacket(&USBD_Device);
-        HAL_Delay(1); // TODO: why not blocking?
+        DWT_Delay(1000); // TODO: why not blocking?
     }
     return 0;
 }

--- a/BSP/flash.ld
+++ b/BSP/flash.ld
@@ -34,8 +34,8 @@ ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
 /* Generate a link error if heap and stack don't fit into RAM */
-_Min_Heap_Size = 0x200;      /* required amount of heap  */
-_Min_Stack_Size = 0x400; /* required amount of stack */
+_Min_Heap_Size = 0x8000;  /* required amount of heap  */
+_Min_Stack_Size = 0x1000; /* required amount of stack */
 
 /* Specify the memory areas */
 MEMORY

--- a/external/middleware/FreeRTOS/CMakeLists.txt
+++ b/external/middleware/FreeRTOS/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(FreeRTOS STATIC
     src/timers.c
     src/portable/Common/mpu_wrappers.c
     src/portable/GCC/ARM_CM7/r0p1/port.c
-    src/portable/MemMang/heap_4.c
+    src/portable/MemMang/heap_3.c
 )
 
 target_include_directories(FreeRTOS PUBLIC

--- a/external/middleware/FreeRTOS/src/include/FreeRTOSConfig.h
+++ b/external/middleware/FreeRTOS/src/include/FreeRTOSConfig.h
@@ -130,6 +130,7 @@ to exclude the API function. */
 #define INCLUDE_vTaskDelayUntil        1
 #define INCLUDE_vTaskDelay             1
 #define INCLUDE_xTaskGetSchedulerState 1
+#define INCLUDE_xSemaphoreGetMutexHolder 1
 
 /* Cortex-M specific definitions. */
 #ifdef __NVIC_PRIO_BITS


### PR DESCRIPTION
This contains some small tweaks that were necessary to get RTOS into a fully-operational state. The biggest fix is that `printf` no longer uses `HAL_Delay`, which was breaking a lot of things. Other than that, I also switched to using `heap_3`, which just calls `malloc()` and uses the heap that we already have available (so I expanded the size of that heap substantially).